### PR TITLE
ci(workflow): remove social media inputs from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,4 @@ jobs:
       extension-name: BreakpointNotifier
       display-name: 'Breakpoint Notifier'
       marketplace-id: CodingWithCalvin.VS-BreakpointNotifier
-      description: 'Opens a dialog box when a breakpoint is hit - great for multi-tasking!'
-      hashtags: '#debugging'
     secrets: inherit


### PR DESCRIPTION
## Summary
- Remove social media inputs (`description`, `hashtags`) from publish workflow that are no longer used by the reusable vsix-publish workflow

## Test plan
- [ ] Verify publish workflow still works correctly